### PR TITLE
Update to supported version of circleci base image.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,13 +2,8 @@ version: 2
 jobs:
   build:
     docker:
-      - image: docker:17.09.0-ce-git
+      - image: cimg/base:2023.12
     steps:
-      - run:
-          name: Update docker container to work with modern GitHub certificates
-          command: |
-            ssh-keyscan -H github.com >> ~/.ssh/known_hosts
-            git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
       - checkout
       - setup_remote_docker
       - run:


### PR DESCRIPTION
Update to supported version of circleci base image.

* Includes docker.
* Image docs: https://circleci.com/developer/images/image/cimg/base
* Remove unnecessary GH host key hackery.
